### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,7 @@ beautifulsoup4==4.12.0
 flask==2.3.2
 websocket-client==1.5.1
 google-generativeai==0.3.1
-request
 speechrecognition
 pyttsx3
 wikipedia
-requests
 pyjokes


### PR DESCRIPTION
This pull request addresses the issue #25  regarding a typo in the `requirements.txt` file. The original error message was:

### Changes Made:
remove the two requirements 
request // as wrong module
requests // as above already mentioned requests==2.28.1