### PR TITLE
Fix: add-contributor.yml garbage commits

### DIFF
--- a/.github/workflows/add-contributor.yml
+++ b/.github/workflows/add-contributor.yml
@@ -2,7 +2,7 @@ name: Update Contributors in README
 
 on:
     push:
-        branches: ["main","yash/fix-17+20"]
+        branches: ["main"]
     workflow_dispatch:
     schedule:
         - cron: "0 0 * * *"
@@ -20,9 +20,5 @@ jobs:
 
             - name: Update Contributors List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
-              with:
-                commit_message: "Updated contributors list"
-                committer_username: "yashksaini-coder"
-                committer_email: "115717039+yashksaini-coder@users.noreply.github.com"
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
✅ Fixes: #155

This PR removes the unnecessary parameters from the `Update Contributors List` job. that were initially used in the config list. It should run automatically on the **main** branch.

Workflow trigger updates:

* [`.github/workflows/add-contributor.yml`](diffhunk://#diff-f11b4db8ec4e64c191e5b311659ac5e7cd4ef61a72741f404b8cbb537bdd13c5L5-R5): Restricted the workflow to trigger only on pushes to the `main` branch.

Job configuration simplification:

* [`.github/workflows/add-contributor.yml`](diffhunk://#diff-f11b4db8ec4e64c191e5b311659ac5e7cd4ef61a72741f404b8cbb537bdd13c5L23-L26): Removed the `commit_message`, `committer_username`, and `committer_email` parameters from the `Update Contributors List` job, simplifying the configuration.